### PR TITLE
Fio bank account data

### DIFF
--- a/fio_2900172106_2024-10-23_2026-01-11.csv
+++ b/fio_2900172106_2024-10-23_2026-01-11.csv
@@ -1,0 +1,42 @@
+Datum;Částka;Typ;Název protiúčtu;Zpráva pro příjemce;KS;VS;SS;Poznámka
+19.01.2025;400,00 CZK;Okamžitá příchozí platba;ALEXANDR KASAL;Sasa Kasal - CAS clenstvi. moc diky, ze to drzite v chodu!;;;;ALEXANDR KASAL
+20.01.2025;150,00 CZK;Bezhotovostní příjem;VERONIKA KRIZ;VERONIKA KRIZ;;;;VERONIKA KRIZ
+20.01.2025;150,00 CZK;Okamžitá příchozí platba;Králová Lenka;;0000;;;Králová Lenka
+20.01.2025;150,00 CZK;Okamžitá příchozí platba;Radek Hůlka;Kateřina Hůlková;;;;Radek Hůlka
+20.01.2025;150,00 CZK;Okamžitá příchozí platba;Radek Hůlka;Radek Hůlka;;;;Radek Hůlka
+20.01.2025;400,00 CZK;Platba převodem uvnitř banky;Manďáková, Alena;Petr Manďák;;;;Petr Manďák
+24.01.2025;150,00 CZK;Okamžitá příchozí platba;Bc. Petr Panoška;Tereza Střílková - členský příspěvek;;;;Bc. Petr Panoška
+24.01.2025;150,00 CZK;Okamžitá příchozí platba;Ondřej Kváš;Ondřej Kváš;;;;Ondřej Kváš
+25.01.2025;150,00 CZK;Okamžitá příchozí platba;Šedivý Daniel;Daniel Šedivý;;;;Šedivý Daniel
+30.01.2025;400,00 CZK;Okamžitá příchozí platba;Šára Jakub;JAkub Šára ČLENSTVÍ;0000;;;Šára Jakub
+31.01.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+31.01.2025;-9 000,00 CZK;Okamžitá odchozí platba;;;;;;JŠ dar
+02.02.2025;150,00 CZK;Okamžitá příchozí platba;Kristýna Pelíšková;Kristýna Pelíšková;;;;Kristýna Pelíšková
+11.02.2025;150,00 CZK;Okamžitá příchozí platba;Jerijová Milada;Milada Jerijová cas clenstvi;0000;;;Jerijová Milada
+21.02.2025;150,00 CZK;Okamžitá příchozí platba;Bc. Petr Panoška;Michal Foltis - členský příspěvek;;;;Bc. Petr Panoška
+25.02.2025;-890,00 CZK;Karetní transakce;;Nákup: 123-TRANSPORTER.CZ, PRAHA, CZ, dne 24.2.2025, částka 890.00 CZK;;0353;;Nákup: 123-TRANSPORTER.CZ, PRAHA, CZ, dne 24.2.2025, částka 890.00 CZK
+28.02.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+21.03.2025;400,00 CZK;Bezhotovostní příjem;ANNA HANUS KUCHAROVA;ANNA HANUS KUCHAROVA;;;;ANNA HANUS KUCHAROVA
+31.03.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+11.04.2025;-678,00 CZK;Okamžitá odchozí platba;;;;8603553456;;ukončení pojistné smlouvy
+30.04.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+06.05.2025;300,00 CZK;Okamžitá příchozí platba;Ilinčev David;;0000;;;Ilinčev David
+12.05.2025;-193,60 CZK;Platba převodem uvnitř banky;;DOMENA+CZECH-SLACKLINE.CZ++04.06.2025+-+03.06.2026;;3125192595;;DOMENA+CZECH-SLACKLINE.CZ++04.06.2025+-+03.06.2026
+12.05.2025;-193,60 CZK;Platba převodem uvnitř banky;;DOMENA+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2026;;3125192594;;DOMENA+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2026
+14.05.2025;-776,97 CZK;Platba převodem uvnitř banky;;WEBHOSTING+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2;;3225054108;;WEBHOSTING+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2
+06.06.2025;150,00 CZK;Okamžitá příchozí platba;Jakub Smagin;Jakub Smagin;;;;Jakub Smagin
+31.10.2025;13 000,00 CZK;Bezhotovostní příjem;STATUTÁRNÍ MĚSTO KLA;Zabezpeceni akce Slackline - prechod 1. a 2. vezak;0000;202501;0;STATUTÁRNÍ MĚSTO KLA
+03.11.2025;-2 000,00 CZK;Okamžitá odchozí platba;;Jakub Šára - odměna za pomoc a půjčení materiálu během události Highline Rozdělovské věžáky 2025;;;;Jakub Šára - odměna za pomoc a půjčení materiálu během události Highline Rozdělovské věžáky 2025
+08.11.2025;20,00 CZK;Okamžitá příchozí platba;Antonín Grulich;omluva;;;;Antonín Grulich
+21.11.2025;-799,00 CZK;Platba převodem uvnitř banky;;CESKA ASOCIACE SLACKLINE, Z.S.;;920250044;;CESKA ASOCIACE SLACKLINE, Z.S.
+02.01.2026;150,00 CZK;Bezhotovostní příjem;JAKUB TRÁVNÍK;JAKUB TRÁVNÍK - ČLENSTVÍ ČAS;0000;0;0;JAKUB TRÁVNÍK
+08.01.2026;150,00 CZK;Okamžitá příchozí platba;Brabcová Markéta;Slackalendář - příspěvek;0000;;;Brabcová Markéta
+08.01.2026;150,00 CZK;Okamžitá příchozí platba;Šedivý Daniel;Slackalendář - příspěvek;;;;Šedivý Daniel
+09.01.2026;150,00 CZK;Okamžitá příchozí platba;Nela Duchoslavová;Slackalendář - příspěvek;;;;Nela Duchoslavová
+09.01.2026;150,00 CZK;Okamžitá příchozí platba;TOMÁŠ VALENTA;Slackalendář - příspěvek;;;;TOMÁŠ VALENTA
+09.01.2026;503,00 CZK;Okamžitá příchozí platba;Adam Máčel;Slackalendář - příspěvek Adamski 200 Phillipski 303;;;;Adam Máčel
+10.01.2026;150,00 CZK;Okamžitá příchozí platba;TEREZA RITTEROVÁ;Slackalendář - příspěvek, Tere Ritter;;;;TEREZA RITTEROVÁ
+10.01.2026;150,00 CZK;Okamžitá příchozí platba;ZUZANA KOŘENOVÁ;Slackalendář - příspěvek;;;;ZUZANA KOŘENOVÁ
+10.01.2026;200,00 CZK;Okamžitá příchozí platba;Bc. Petr Panoška;Slackalendář - příspěvek - Adam Janata;;;;Bc. Petr Panoška
+10.01.2026;500,00 CZK;Okamžitá příchozí platba;Boček Tomáš;Slackalendář - příspěvek;0000;;;Boček Tomáš
+11.01.2026;150,00 CZK;Okamžitá příchozí platba;Silvie Doležalová;Slackalendář - příspěvek;;;;Silvie Doležalová

--- a/fio_2900172106_2025-01-11_2026-01-11.csv
+++ b/fio_2900172106_2025-01-11_2026-01-11.csv
@@ -1,0 +1,42 @@
+Datum;Částka;Typ;Název protiúčtu;Zpráva pro příjemce;KS;VS;SS;Poznámka
+19.01.2025;400,00 CZK;Okamžitá příchozí platba;ALEXANDR KASAL;Sasa Kasal - CAS clenstvi. moc diky, ze to drzite v chodu!;;;;ALEXANDR KASAL
+20.01.2025;150,00 CZK;Bezhotovostní příjem;VERONIKA KRIZ;VERONIKA KRIZ;;;;VERONIKA KRIZ
+20.01.2025;150,00 CZK;Okamžitá příchozí platba;Králová Lenka;;0000;;;Králová Lenka
+20.01.2025;150,00 CZK;Okamžitá příchozí platba;Radek Hůlka;Kateřina Hůlková;;;;Radek Hůlka
+20.01.2025;150,00 CZK;Okamžitá příchozí platba;Radek Hůlka;Radek Hůlka;;;;Radek Hůlka
+20.01.2025;400,00 CZK;Platba převodem uvnitř banky;Manďáková, Alena;Petr Manďák;;;;Petr Manďák
+24.01.2025;150,00 CZK;Okamžitá příchozí platba;Bc. Petr Panoška;Tereza Střílková - členský příspěvek;;;;Bc. Petr Panoška
+24.01.2025;150,00 CZK;Okamžitá příchozí platba;Ondřej Kváš;Ondřej Kváš;;;;Ondřej Kváš
+25.01.2025;150,00 CZK;Okamžitá příchozí platba;Šedivý Daniel;Daniel Šedivý;;;;Šedivý Daniel
+30.01.2025;400,00 CZK;Okamžitá příchozí platba;Šára Jakub;JAkub Šára ČLENSTVÍ;0000;;;Šára Jakub
+31.01.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+31.01.2025;-9 000,00 CZK;Okamžitá odchozí platba;;;;;;JŠ dar
+02.02.2025;150,00 CZK;Okamžitá příchozí platba;Kristýna Pelíšková;Kristýna Pelíšková;;;;Kristýna Pelíšková
+11.02.2025;150,00 CZK;Okamžitá příchozí platba;Jerijová Milada;Milada Jerijová cas clenstvi;0000;;;Jerijová Milada
+21.02.2025;150,00 CZK;Okamžitá příchozí platba;Bc. Petr Panoška;Michal Foltis - členský příspěvek;;;;Bc. Petr Panoška
+25.02.2025;-890,00 CZK;Karetní transakce;;Nákup: 123-TRANSPORTER.CZ, PRAHA, CZ, dne 24.2.2025, částka 890.00 CZK;;0353;;Nákup: 123-TRANSPORTER.CZ, PRAHA, CZ, dne 24.2.2025, částka 890.00 CZK
+28.02.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+21.03.2025;400,00 CZK;Bezhotovostní příjem;ANNA HANUS KUCHAROVA;ANNA HANUS KUCHAROVA;;;;ANNA HANUS KUCHAROVA
+31.03.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+11.04.2025;-678,00 CZK;Okamžitá odchozí platba;;;;8603553456;;ukončení pojistné smlouvy
+30.04.2025;-10,00 CZK;Poplatek - platební karta;;poplatek za pojištění;;0353;;poplatek za pojištění
+06.05.2025;300,00 CZK;Okamžitá příchozí platba;Ilinčev David;;0000;;;Ilinčev David
+12.05.2025;-193,60 CZK;Platba převodem uvnitř banky;;DOMENA+CZECH-SLACKLINE.CZ++04.06.2025+-+03.06.2026;;3125192595;;DOMENA+CZECH-SLACKLINE.CZ++04.06.2025+-+03.06.2026
+12.05.2025;-193,60 CZK;Platba převodem uvnitř banky;;DOMENA+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2026;;3125192594;;DOMENA+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2026
+14.05.2025;-776,97 CZK;Platba převodem uvnitř banky;;WEBHOSTING+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2;;3225054108;;WEBHOSTING+CESKA-ASOCIACE-SLACKLINE.CZ++04.06.2025+-+03.06.2
+06.06.2025;150,00 CZK;Okamžitá příchozí platba;Jakub Smagin;Jakub Smagin;;;;Jakub Smagin
+31.10.2025;13 000,00 CZK;Bezhotovostní příjem;STATUTÁRNÍ MĚSTO KLA;Zabezpeceni akce Slackline - prechod 1. a 2. vezak;0000;202501;0;STATUTÁRNÍ MĚSTO KLA
+03.11.2025;-2 000,00 CZK;Okamžitá odchozí platba;;Jakub Šára - odměna za pomoc a půjčení materiálu během události Highline Rozdělovské věžáky 2025;;;;Jakub Šára - odměna za pomoc a půjčení materiálu během události Highline Rozdělovské věžáky 2025
+08.11.2025;20,00 CZK;Okamžitá příchozí platba;Antonín Grulich;omluva;;;;Antonín Grulich
+21.11.2025;-799,00 CZK;Platba převodem uvnitř banky;;CESKA ASOCIACE SLACKLINE, Z.S.;;920250044;;CESKA ASOCIACE SLACKLINE, Z.S.
+02.01.2026;150,00 CZK;Bezhotovostní příjem;JAKUB TRÁVNÍK;JAKUB TRÁVNÍK - ČLENSTVÍ ČAS;0000;0;0;JAKUB TRÁVNÍK
+08.01.2026;150,00 CZK;Okamžitá příchozí platba;Brabcová Markéta;Slackalendář - příspěvek;0000;;;Brabcová Markéta
+08.01.2026;150,00 CZK;Okamžitá příchozí platba;Šedivý Daniel;Slackalendář - příspěvek;;;;Šedivý Daniel
+09.01.2026;150,00 CZK;Okamžitá příchozí platba;Nela Duchoslavová;Slackalendář - příspěvek;;;;Nela Duchoslavová
+09.01.2026;150,00 CZK;Okamžitá příchozí platba;TOMÁŠ VALENTA;Slackalendář - příspěvek;;;;TOMÁŠ VALENTA
+09.01.2026;503,00 CZK;Okamžitá příchozí platba;Adam Máčel;Slackalendář - příspěvek Adamski 200 Phillipski 303;;;;Adam Máčel
+10.01.2026;150,00 CZK;Okamžitá příchozí platba;TEREZA RITTEROVÁ;Slackalendář - příspěvek, Tere Ritter;;;;TEREZA RITTEROVÁ
+10.01.2026;150,00 CZK;Okamžitá příchozí platba;ZUZANA KOŘENOVÁ;Slackalendář - příspěvek;;;;ZUZANA KOŘENOVÁ
+10.01.2026;200,00 CZK;Okamžitá příchozí platba;Bc. Petr Panoška;Slackalendář - příspěvek - Adam Janata;;;;Bc. Petr Panoška
+10.01.2026;500,00 CZK;Okamžitá příchozí platba;Boček Tomáš;Slackalendář - příspěvek;0000;;;Boček Tomáš
+11.01.2026;150,00 CZK;Okamžitá příchozí platba;Silvie Doležalová;Slackalendář - příspěvek;;;;Silvie Doležalová


### PR DESCRIPTION
Download Fio transparent account transactions and save them as CSV files.

The Fio transparent account page `ib.fio.cz/ib/transparent` currently limits transaction exports to approximately the last 365 days. Although the user requested data from `23.10.2024`, the server only provided transactions starting from `11.01.2025` (one year prior to the current date `11.01.2026`). Attempts to use the Fio REST API were unsuccessful due to redirects. Two CSV files are provided, reflecting the available data within the server's limitation.

---
<a href="https://cursor.com/background-agent?bcId=bc-85735c8b-9560-4f52-aa40-e341177b6713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85735c8b-9560-4f52-aa40-e341177b6713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

